### PR TITLE
zoyo-footer: Fix shrinking

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
               <img class="figure" src="https://via.placeholder.com/300x200">
               <img class="figure" src="https://via.placeholder.com/300x200">
           </div>
-          <div class="toolbar toolbar-footer" style="bottom: 0px;">
+          <div class="toolbar toolbar-footer zoyo-footer" style="bottom: 0px;">
             <div class="zoyo-header" style="padding-top: 20px; padding-bottom: 20px;">
               <div class="left-buttons">
                 <button class="btn btn-large btn-default">
@@ -169,7 +169,7 @@
     justify-content: space-between;
     background-image: linear-gradient(black, darkslategray);
     overflow: hidden;
-}
+  }
 
   .zoyo-header {
     display: flex;
@@ -216,6 +216,10 @@
     box-shadow: 0px 2px 3px rgba(0,0,0,.13) ,1px 2px 2px rgba(0,0,0,.1) , -1px -2px 2px rgba(0,0,0,.05) ;
     flex-grow: 1;
 
+  }
+
+  .zoyo-footer {
+    flex-shrink: 0;
   }
 
 </style>


### PR DESCRIPTION
Também corrige a indentação do close bracket (`}`) na linha 172.